### PR TITLE
Add avahi-tools package, needed for external-mdns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN 	apk -U add \
               mbedtls \
               soxr \
               avahi \
+              avahi-tools \
               libconfig \
               libsndfile \
               mosquitto-libs \


### PR DESCRIPTION
The docs provide some info that compiling --with-external-mdns solves the problem of trying to run multiple zeroconf services on the same stack. But to get it working, you need to install `avahi-publish-service` or `mDNSPublish`. `avahi-publish-service` is in `avahi-tools` APK, and installing it by default could save people some debugging with little extra overhead.